### PR TITLE
[Fix]临时修复无法退出app

### DIFF
--- a/electron-static/main.js
+++ b/electron-static/main.js
@@ -15,7 +15,7 @@ var win;
 function createWindow () {
     // Create the browser window.
     win = new BrowserWindow({width: 1080, height: 1920,frame:false});
-    win.setFullScreen(true);
+    win.setFullScreen(false);
  
     // and load the index.html of the app.
     const port = s.address().port;


### PR DESCRIPTION
在#8 中 我说明可以通过修改`electron-static\main.js`文件中第18行的代码
`
win.setfullscreen(true);
`
更改为
`
win.setfullscreen(**false**);
`
用禁用自动全屏的方法来暂时解决无法关闭的bug（主要还是让系统任务栏显示出来，方便右键关闭）